### PR TITLE
fix(sections): update so other tasks are moved over, in callout or not

### DIFF
--- a/src/sections.ts
+++ b/src/sections.ts
@@ -78,13 +78,14 @@ export async function extractUncheckedItemsFromSections({
     if (shouldSkip) continue;
 
     // Match tasks inside callouts: "> - [ ]" or ">- [ ]" (with or without space after >)
+    // Also supports nested tasks with indentation: ">    - [ ]"
     if (trimmedLine.match(/^>\s*[-*+]\s+\[\s\]/)) {
       // Preserve the original spacing from the source file
       unchecked.push(line);
       logger.info(`Found unchecked task in callout: ${trimmedLine}`);
     }
-    // Match regular tasks: "- [ ]"
-    else if (trimmedLine.match(/^[-*+]\s+\[\s\]/)) {
+    // Match regular tasks: "- [ ]", including nested tasks with leading whitespace
+    else if (trimmedLine.match(/^\s*[-*+]\s+\[\s\]/)) {
       unchecked.push(`${calloutPrefix}${line}`);
       logger.info(`Found unchecked task: ${trimmedLine}`);
     }


### PR DESCRIPTION
sorry to merge this in without waiting for approval, but it kinda broke on my work machine. i use nested tasks a lot and there's some whitespace inconsistency with callouts, so this resolves that.

enforces these items transfer over:
<img width="334" height="158" alt="image" src="https://github.com/user-attachments/assets/931390e8-ff95-4488-a364-891c96c65b6f" />

also, we're making sure tasks in other callouts (that aren't ignored) get picked up as well.